### PR TITLE
Filter out terms

### DIFF
--- a/MMM-Dad-Jokes.js
+++ b/MMM-Dad-Jokes.js
@@ -17,6 +17,7 @@ Module.register("MMM-Dad-Jokes", {
 		title: "Dad Jokes",
 		updateInterval: 60*1000, // every 60 seconds
 		fadeSpeed: 4*1000, // four seconds
+		filters: [],
 	},
 
 	start: function() {
@@ -49,8 +50,14 @@ Module.register("MMM-Dad-Jokes", {
 
 	socketNotificationReceived: function(notification, payload) {
 		if (notification == "JOKE_RESULT") {
-			this.result = payload;
-			this.updateDom(this.config.fadeSpeed);
+			if( this.config.filters.some( term => payload.joke.toLowerCase().indexOf(term) > -1 ) ) {
+				// Filter matched, skip this joke
+				this.getJoke();
+			}
+			else {
+				this.result = payload;
+				this.updateDom(this.config.fadeSpeed);
+			}
 		}
 	},
 });

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ var config = {
 |----------------- |-----------
 | updateInterval   | *Required* How often to grab an amazing joke! Defaults to one minute
 | fadeSpeed        | How quickly the jokes fade in and out. Defaults to four seconds
+| filters          | Array of words not to include in jokes


### PR DESCRIPTION
This permits skipping jokes which contain terms you don't want displayed in language-sensitive spaces.  (e.g. filters: ["damn"])